### PR TITLE
Improve color palette

### DIFF
--- a/colors.js
+++ b/colors.js
@@ -1,4 +1,5 @@
 const backgroundColors = [
+  // 17 light colors
   "#f4f4f4", // light gray
   "#fef6e4", // warm cream
   "#e3f2fd", // soft sky blue
@@ -11,17 +12,19 @@ const backgroundColors = [
   "#fff3e0", // peach mist
   "#e6f7ff", // ice blue
   "#f1f8e9", // garden light
-  "#3e2a47", // dusky violet-purple (moody, not overpowering)
   "#ffe0b2", // apricot glaze
   "#f0ffff", // barely cyan
   "#f9fbe7", // pale spring
   "#e8eaf6", // faded periwinkle
   "#fce4ec", // soft cherry milk
-  "#e0f7fa", // light teal cloud
-  "#f3f3f3", // neutral light gray
-  "#f5ebdc", // warm sand
-  "#cfd8dc", // washed stone
+
+  // 8 dark colors
+  "#3e2a47", // dusky violet
   "#2e3440", // nordic dusk
   "#3b3b3b", // soft charcoal
-  "#1f1f1f"  // deep matte black
+  "#1f1f1f", // deep matte black
+  "#1a237e", // dark indigo
+  "#1b5e20", // deep forest
+  "#4e342e", // espresso brown
+  "#7f0000"  // dark crimson
 ];


### PR DESCRIPTION
## Summary
- refresh `colors.js` palette with better contrast
- provide 17 light backgrounds and 8 dark ones

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_683ff8475b4c833199b8b160dd9ccd6d