### PR TITLE
Improve secret message usability on mobile

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ Simply open `index.html` in your browser. No build step is required; all assets 
 * **versions.js** – Displays the fake version label.
 
 Opening the page loads these scripts to produce a silly, constantly mutating site.
+
+On desktop you can reveal a hidden message by hovering in the bottom left
+corner for a couple of seconds. On touch devices you can press and hold in
+that corner. The page disables text selection there so the overlay appears
+instead of the usual highlight menu.

--- a/index.html
+++ b/index.html
@@ -126,6 +126,9 @@
       width: 100px;
       height: 100px;
       z-index: 100;
+      user-select: none;
+      -webkit-user-select: none;
+      touch-action: none;
     }
 
     #secret-message {
@@ -258,19 +261,26 @@
       const overlay = document.getElementById("overlay");
 
       let hoverTimeout;
-      corner.addEventListener("mouseenter", () => {
+      const startReveal = (e) => {
+        if (e) e.preventDefault();
         hoverTimeout = setTimeout(() => {
           overlay.style.display = "block";
           message.innerText = pickRandom(secretLines);
           message.style.display = "block";
         }, 1800);
-      });
+      };
 
-      corner.addEventListener("mouseleave", () => {
+      const endReveal = () => {
         clearTimeout(hoverTimeout);
         message.style.display = "none";
         overlay.style.display = "none";
-      });
+      };
+
+      corner.addEventListener("mouseenter", startReveal);
+      corner.addEventListener("mouseleave", endReveal);
+      corner.addEventListener("touchstart", startReveal, { passive: false });
+      corner.addEventListener("touchend", endReveal);
+      corner.addEventListener("touchcancel", endReveal);
 
       setTimeout(() => {
         const currentYear = new Date().getFullYear();


### PR DESCRIPTION
## Summary
- allow long press on the hidden corner to reveal the secret message
- document mobile long‑press behaviour in the README
- prevent text selection during long press to keep the overlay visible

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68408885355083318097947a3c94986d